### PR TITLE
feat: add SKILL.md for Claude Code native skill discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ forge-obsidian/
 ├── module.yaml              # Module metadata (name, version, events)
 ├── config.yaml              # Content paths + metadata mapping
 ├── skills/
-│   └── obsidian-conventions/
+│   └── ObsidianConventions/
 │       └── SKILL.md         # Claude Code skill (frontmatter + !`command` body)
 ├── src/
 │   └── SYSTEM.md            # System content (ALL CAPS = module-provided)
@@ -35,7 +35,7 @@ Content delivery follows PAI's progressive disclosure model. Only Tier 1 metadat
 
 ### How It Works
 
-**Claude Code** uses native skill discovery via `skills/obsidian-conventions/SKILL.md`. Claude reads the skill's `description` frontmatter at session start (~30 tokens) and invokes the skill on demand when working with vault files. The SKILL.md body uses `!`command`` preprocessing to dynamically load content through `load_context --body-only`, which pulls system content from `src/SYSTEM.md` and any user content from `config.yaml` paths — including absolute paths outside the repo.
+**Claude Code** uses native skill discovery via `skills/ObsidianConventions/SKILL.md`. Claude reads the skill's `description` frontmatter at session start (~30 tokens) and invokes the skill on demand when working with vault files. The SKILL.md body uses `!`command`` preprocessing to dynamically load content through `load_context --body-only`, which pulls system content from `src/SYSTEM.md` and any user content from `config.yaml` paths — including absolute paths outside the repo.
 
 The SessionStart hook is kept for **other providers** that don't support skill discovery. It emits metadata only via `load_context --index-only`:
 
@@ -86,11 +86,11 @@ claude plugin install forge-obsidian
 
 ## Skill Discovery
 
-Claude Code discovers the skill via `skills/obsidian-conventions/SKILL.md`. The frontmatter follows the [Agent Skills](https://agentskills.io) standard:
+Claude Code discovers the skill via `skills/ObsidianConventions/SKILL.md`. The frontmatter follows the [Agent Skills](https://agentskills.io) standard:
 
 ```yaml
 ---
-name: obsidian-conventions
+name: ObsidianConventions
 description: Vault conventions for wikilinks, frontmatter and tags. USE WHEN working with Obsidian vault files.
 ---
 ```

--- a/skills/ObsidianConventions/SKILL.md
+++ b/skills/ObsidianConventions/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: obsidian-conventions
+name: ObsidianConventions
 description: Vault conventions for wikilinks, frontmatter and tags. USE WHEN working with Obsidian vault files.
 ---
 

--- a/skills/obsidian-conventions/SKILL.md
+++ b/skills/obsidian-conventions/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: obsidian-conventions
+description: Vault conventions for wikilinks, frontmatter and tags. USE WHEN working with Obsidian vault files.
+---
+
+Apply these conventions when working with Obsidian vault files:
+
+!`bash -c 'MODULE_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"; PROJECT_ROOT="${CLAUDE_PROJECT_ROOT:-$(pwd)}"; source "$MODULE_ROOT/lib/load.sh"; load_context "$MODULE_ROOT" "$PROJECT_ROOT" --body-only'`


### PR DESCRIPTION
Claude Code discovers skills via SKILL.md frontmatter, not config.yaml.
Add skills/obsidian-conventions/SKILL.md with proper frontmatter and
!`command` preprocessing that calls load_context --body-only to
dynamically load system and user content at invocation time.

This avoids a build script — shell preprocessing has full filesystem
access so user content paths (including absolute paths outside the repo)
resolve at runtime. SessionStart hook kept for other providers.

https://claude.ai/code/session_0163uc9rzck4FKDdu3cKarcs