### PR TITLE
feat: enable pre-push secret gate (jj + git)

### DIFF
--- a/.githooks/jj-push
+++ b/.githooks/jj-push
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# forge jj push gate. jj runs no git hooks, so the pre-push gate is relocated here.
+# Wired by `make install` as the repo-local jj `push` alias (absolute path so it
+# resolves from any working directory):
+#   jj config set --repo aliases.push '["util","exec","--","bash","<repo>/.githooks/jj-push"]'
+# Runs the same pre-push gate as git's pre-push hook, then hands off to jj git push.
+# Canonical source: https://github.com/N4M3Z/forge-cli/blob/main/templates/init/.githooks/jj-push
+
+# cd to the repo root so prek finds .pre-commit-config.yaml regardless of cwd.
+cd "$(jj workspace root 2>/dev/null || git rev-parse --show-toplevel 2>/dev/null || dirname "$0")"
+
+if command -v prek >/dev/null 2>&1; then
+    prek run --all-files --stage pre-push
+elif command -v forge >/dev/null 2>&1; then
+    forge validate
+fi
+
+exec jj git push "$@"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# forge module pre-push hook — runs the pre-push-staged gates (gitleaks, semgrep).
+# Canonical source: https://github.com/N4M3Z/forge-cli/blob/main/templates/init/.githooks/pre-push
+
+SCRIPT_URL="https://raw.githubusercontent.com/N4M3Z/forge-cli/main/scripts/validate.sh"
+SCRIPT_SHA="55998b60a7e972c09c9bcc9767d675b95e011e58309c69849b44fec994909d0b"
+
+if command -v prek >/dev/null 2>&1; then
+    prek run --all-files --stage pre-push
+elif command -v forge >/dev/null 2>&1; then
+    forge validate
+else
+    echo ""
+    echo "  ⚠  Neither prek nor forge found — using validate.sh fallback"
+    echo "     Install: cargo install --locked forge-cli   or   cargo binstall prek"
+    echo ""
+
+    tmpdir=$(mktemp -d)
+    trap 'rm -rf "$tmpdir"' EXIT
+
+    curl --max-time 30 -sfL "$SCRIPT_URL" -o "$tmpdir/validate.sh" 2>/dev/null \
+        || { echo "validate.sh unreachable — install forge-cli or check connectivity"; exit 1; }
+
+    actual=$(sha256sum "$tmpdir/validate.sh" 2>/dev/null || shasum -a 256 "$tmpdir/validate.sh")
+    actual=${actual%% *}
+
+    if [ "$actual" != "$SCRIPT_SHA" ]; then
+        echo "validate.sh hash mismatch (expected $SCRIPT_SHA, got $actual)"
+        echo "  update SCRIPT_SHA after verifying the new script"
+        exit 1
+    fi
+
+    bash "$tmpdir/validate.sh" .
+fi

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,7 @@
+[extend]
+useDefault = true
+
+[allowlist]
+paths = [
+    "evals/baselines/.*",
+]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,41 @@
+repos:
+    - repo: builtin
+      hooks:
+          - id: trailing-whitespace
+          - id: check-yaml
+            exclude: ^templates/
+          - id: check-json
+
+    - repo: local
+      hooks:
+          - id: shellcheck
+            name: shellcheck
+            entry: shellcheck -S warning
+            language: system
+            types: [shell]
+
+          - id: ruff
+            name: ruff check
+            entry: ruff check
+            language: system
+            types: [python]
+
+          - id: gitleaks
+            name: gitleaks
+            entry: gitleaks detect --no-banner
+            language: system
+            pass_filenames: false
+            stages: [pre-push]
+
+          - id: semgrep
+            name: semgrep OWASP
+            entry: semgrep scan --config=p/owasp-top-ten --metrics=off --quiet .
+            language: system
+            pass_filenames: false
+            stages: [pre-push]
+
+          - id: forge-validate
+            name: forge validate
+            entry: forge validate
+            language: system
+            pass_filenames: false


### PR DESCRIPTION
Wires up the pre-push secret gate here. jj doesn't run git hooks, so without a `jj push` alias the gate never fires under jj. This adds `.githooks/jj-push` (runs the pre-push stage before `jj git push`) and `.githooks/pre-push` for git, plus `useDefault` in `.gitleaks.toml`. The gitleaks command is `detect`, which works on CI's older apt gitleaks.

Same change `forge init` now scaffolds (N4M3Z/forge-cli#62). gitleaks scan came back clean.
